### PR TITLE
feat: Ignora versão do php no build

### DIFF
--- a/.github/workflows/PHP.yml
+++ b/.github/workflows/PHP.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Installs composer
       run: |
         cd php;
-        composer install -n --prefer-dist
+        composer install -n --prefer-dist --ignore-platform-req=php
 
     - name: Configure PHPCS
       run: |


### PR DESCRIPTION
Pois alguns candidatos estão usando versões que não são suportadas oficialmente pelo openspout (apesar dele funcionar nelas)